### PR TITLE
Pin GitHub Actions to commit SHAs

### DIFF
--- a/automations/action.yml
+++ b/automations/action.yml
@@ -7,17 +7,17 @@ runs:
   using: composite
   steps:
     - name: Set up Python
-      uses: actions/setup-python@v5.6.0
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
       with:
         python-version: '3.10'
     - name: Check out ESPHome from GitHub
-      uses: actions/checkout@v4.2.2
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
       with:
         repository: esphome/esphome
         ref: ${{ inputs.version }}
         path: esphome
     - name: Set up UV
-      uses: astral-sh/setup-uv@v6.1.0
+      uses: astral-sh/setup-uv@f0ec1fc3b38f5e7cd731bb6ce540c5af426746bb  # v6.1.0
       with:
         working-directory: esphome
         activate-environment: true
@@ -31,7 +31,7 @@ runs:
         mkdir -p output/${{ inputs.version }}
         ./automations/get-automations.sh esphome > output/${{ inputs.version }}/automations.json
     - name: Validate schema
-      uses: cardinalby/schema-validator-action@3.1.1
+      uses: cardinalby/schema-validator-action@2166123eb256fa40baef7e22ab1379708425efc7  # 3.1.1
       with:
         file: output/${{ inputs.version }}/automations.json
         schema: automations/schema.json
@@ -40,7 +40,7 @@ runs:
       if: ${{ inputs.version == 'dev' }}
       run: cp automations/schema.json output/automations.schema.json
     - name: Upload artifact
-      uses: actions/upload-artifact@v4.6.2
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
       with:
         name: automations-${{ inputs.version }}
         path: output

--- a/component-changes/action.yml
+++ b/component-changes/action.yml
@@ -3,7 +3,7 @@ runs:
   using: composite
   steps:
     - name: Check out release branch from GitHub
-      uses: actions/checkout@v4.2.2
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
       with:
         repository: esphome/esphome
         ref: release
@@ -15,7 +15,7 @@ runs:
         mkdir output
         ./component-changes/get-changes.sh esphome > output/changed_components.json
     - name: Validate schema
-      uses: cardinalby/schema-validator-action@v3
+      uses: cardinalby/schema-validator-action@77eb17b070f282db4680215551cae4d9c379f2f4  # v3
       with:
         file: output/changed_components.json
         schema: component-changes/schema.json
@@ -23,7 +23,7 @@ runs:
       shell: bash
       run: cp component-changes/schema.json output/changed_components.schema.json
     - name: Upload artifact
-      uses: actions/upload-artifact@v4.6.2
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
       with:
         name: component-changes
         path: output

--- a/components/action.yml
+++ b/components/action.yml
@@ -3,7 +3,7 @@ runs:
   using: composite
   steps:
     - name: Check out ESPHome from GitHub
-      uses: actions/checkout@v4.2.2
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
       with:
         repository: esphome/esphome
         ref: dev
@@ -14,7 +14,7 @@ runs:
         mkdir -p output
         ./components/get-components.sh esphome > output/components.json
     - name: Validate schema
-      uses: cardinalby/schema-validator-action@3.1.1
+      uses: cardinalby/schema-validator-action@2166123eb256fa40baef7e22ab1379708425efc7  # 3.1.1
       with:
         file: output/components.json
         schema: components/schema.json
@@ -22,7 +22,7 @@ runs:
       shell: bash
       run: cp components/schema.json output/components.schema.json
     - name: Upload artifact
-      uses: actions/upload-artifact@v4.6.2
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
       with:
         name: components
         path: output


### PR DESCRIPTION
## Summary

Pin all GitHub Action and reusable workflow references to their full commit SHAs
instead of mutable tags or branch names.

## Why?

Referencing actions by tag (e.g., `actions/checkout@v4`) is convenient but
carries a supply-chain risk: tags are mutable and can be force-pushed to point
at arbitrary commits. If an action's tag is compromised, every workflow that
references it by tag will silently run the attacker's code.

Pinning to a full 40-character commit SHA (e.g.,
`actions/checkout@11bd719...`) makes the reference immutable. Even if a tag is
tampered with, workflows pinned to a SHA will continue to use the exact code
that was reviewed and trusted.

A version comment is included next to each SHA for readability
(e.g., `actions/checkout@11bd719... # v4.2.2`).

## References

- [GitHub Blog: Four tips to keep your GitHub Actions workflows secure](https://github.blog/open-source/four-tips-to-keep-your-github-actions-workflows-secure/#use-specific-action-version-tags)
- [GitHub Docs: Security hardening for GitHub Actions](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions)
- [GitHub Docs: Enforcing SHA pinning for actions](https://docs.github.com/en/organizations/managing-organization-settings/disabling-or-limiting-github-actions-for-your-organization#requiring-workflows-to-use-pinned-versions-of-actions)
